### PR TITLE
remove cereal (and thus json logic) from global headers

### DIFF
--- a/cocos/base/CCValue.cpp
+++ b/cocos/base/CCValue.cpp
@@ -29,6 +29,15 @@
 #include <iomanip>
 #include "base/ccUtils.h"
 
+#include "cereal/cereal.hpp"
+#include "cereal/access.hpp"
+#include "cereal/types/common.hpp"
+#include "cereal/types/string.hpp"
+#include "cereal/types/map.hpp"
+#include "cereal/types/vector.hpp"
+#include "cereal/types/memory.hpp"
+#include "cereal/archives/binary.hpp"
+
 NS_CC_BEGIN
 
 const ValueVector ValueVectorNull;

--- a/cocos/base/CCValue.h
+++ b/cocos/base/CCValue.h
@@ -26,14 +26,6 @@
 #ifndef __cocos2d_libs__CCValue__
 #define __cocos2d_libs__CCValue__
 
-#include "cereal/cereal.hpp"
-#include "cereal/access.hpp"
-#include "cereal/types/common.hpp"
-#include "cereal/types/string.hpp"
-#include "cereal/types/map.hpp"
-#include "cereal/types/vector.hpp"
-#include "cereal/types/memory.hpp"
-#include "cereal/archives/binary.hpp"
 #include "platform/CCPlatformMacros.h"
 #include "base/ccMacros.h"
 #include <string>

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -34,6 +34,16 @@ THE SOFTWARE.
 #include "platform/CCSAXParser.h"
 //#include "base/ccUtils.h"
 
+#include "cereal/cereal.hpp"
+#include "cereal/access.hpp"
+#include "cereal/types/common.hpp"
+#include "cereal/types/string.hpp"
+#include "cereal/types/map.hpp"
+#include "cereal/types/vector.hpp"
+#include "cereal/types/memory.hpp"
+#include "cereal/archives/binary.hpp"
+#include "cereal/archives/json.hpp"
+
 #include "tinyxml2/tinyxml2.h"
 #ifdef MINIZIP_FROM_SYSTEM
 #include <minizip/unzip.h>

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -36,10 +36,6 @@ THE SOFTWARE.
     #include <filesystem>
 #endif
 
-#include "cereal/cereal.hpp"
-#include "cereal/access.hpp"
-#include "cereal/archives/binary.hpp"
-#include "cereal/archives/json.hpp"
 #include "platform/CCPlatformMacros.h"
 #include "base/ccTypes.h"
 #include "base/CCValue.h"


### PR DESCRIPTION
prevent a header only serializer implementations from leaking into literally everything.